### PR TITLE
Register BG config values with config condition

### DIFF
--- a/src/main/java/com/minecraftabnormals/berry_good/core/BGConfig.java
+++ b/src/main/java/com/minecraftabnormals/berry_good/core/BGConfig.java
@@ -1,5 +1,6 @@
 package com.minecraftabnormals.berry_good.core;
 
+import com.minecraftabnormals.abnormals_core.core.annotations.ConfigKey;
 import net.minecraftforge.common.ForgeConfigSpec;
 import net.minecraftforge.common.ForgeConfigSpec.ConfigValue;
 import net.minecraftforge.fml.common.Mod.EventBusSubscriber;
@@ -9,9 +10,15 @@ import org.apache.commons.lang3.tuple.Pair;
 public class BGConfig {
 
 	public static class Common {
+
+		@ConfigKey("berry_bush_requires_pips")
 		public final ConfigValue<Boolean> berriesRequirePips;
 
+
+		@ConfigKey("fox_music_disc_enabled")
 		public final ConfigValue<Boolean> foxMusicDisc;
+
+		@ConfigKey("fox_music_disc_spawn_chance")
 		public final ConfigValue<Double> foxMusicDiscChance;
 
 		Common(ForgeConfigSpec.Builder builder) {

--- a/src/main/java/com/minecraftabnormals/berry_good/core/BerryGood.java
+++ b/src/main/java/com/minecraftabnormals/berry_good/core/BerryGood.java
@@ -35,6 +35,7 @@ public class BerryGood {
 		bus.addListener(this::dataSetup);
 
 		ModLoadingContext.get().registerConfig(ModConfig.Type.COMMON, BGConfig.COMMON_SPEC);
+		DataUtil.registerConfigCondition(BerryGood.MOD_ID, BGConfig.COMMON);
 	}
 
 	private void commonSetup(FMLCommonSetupEvent event) {


### PR DESCRIPTION
This is a PR I've been meaning to do for ages, but I haven't got around to until now. A while ago a config condition system was added to Abnormals Core which lets recipes, advancement/loot modifiers, loot tables and whatever else use the value of a config entry as a json condition, like this:
```
"conditions": [
  {
    "type": "abnormals_core:config",
    "value": "potato_poison_chance",
    "predicates": [
      {
        "type": "abnormals_core:greater_than_or_equal_to",
        "value": 0.1,
        "inverted": true
      }
    ]
  }
],
//Loot pool/modifier/etc. here
```
To support this, mods need to register their config objects in the `DataUtil#registerConfigCondition` method and annotate all the `ConfigValue` fields with `@ConfigKey` which specifies the string key for that value in json. I've done that for this PR, and I'll change the specific strings used for the config values if anyone requests.