### PR TITLE
fix incorrect berry item filling

### DIFF
--- a/src/main/java/com/teamabnormals/berry_good/core/mixin/CaveVinesBlockMixin.java
+++ b/src/main/java/com/teamabnormals/berry_good/core/mixin/CaveVinesBlockMixin.java
@@ -3,8 +3,11 @@ package com.teamabnormals.berry_good.core.mixin;
 import com.teamabnormals.berry_good.core.BGConfig;
 import com.teamabnormals.berry_good.core.registry.BGItems;
 import net.minecraft.core.BlockPos;
+import net.minecraft.world.item.Item;
 import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.Items;
 import net.minecraft.world.level.BlockGetter;
+import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.state.BlockState;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
@@ -12,7 +15,10 @@ import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
 @Mixin(targets = {"net/minecraft/world/level/block/CaveVinesBlock", "net/minecraft/world/level/block/CaveVinesPlantBlock"})
-public abstract class CaveVinesBlockMixin {
+public class CaveVinesBlockMixin extends Block {
+	private CaveVinesBlockMixin(Properties properties) {
+		super(properties);
+	}
 
 	@Inject(method = "getCloneItemStack", at = @At("RETURN"), cancellable = true)
 	private void getCloneItemStack(BlockGetter level, BlockPos pos, BlockState state, CallbackInfoReturnable<ItemStack> cir) {
@@ -20,4 +26,10 @@ public abstract class CaveVinesBlockMixin {
 			cir.setReturnValue(new ItemStack(BGItems.GLOW_BERRY_PIPS.get()));
 		}
 	}
+
+	@Override
+	public Item asItem() {
+		return Items.GLOW_BERRIES;
+	}
+
 }

--- a/src/main/java/com/teamabnormals/berry_good/core/mixin/SweetBerryBushBlockMixin.java
+++ b/src/main/java/com/teamabnormals/berry_good/core/mixin/SweetBerryBushBlockMixin.java
@@ -3,8 +3,11 @@ package com.teamabnormals.berry_good.core.mixin;
 import com.teamabnormals.berry_good.core.BGConfig;
 import com.teamabnormals.berry_good.core.registry.BGItems;
 import net.minecraft.core.BlockPos;
+import net.minecraft.world.item.Item;
 import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.Items;
 import net.minecraft.world.level.BlockGetter;
+import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.SweetBerryBushBlock;
 import net.minecraft.world.level.block.state.BlockState;
 import org.spongepowered.asm.mixin.Mixin;
@@ -13,7 +16,10 @@ import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
 @Mixin(SweetBerryBushBlock.class)
-public abstract class SweetBerryBushBlockMixin {
+public class SweetBerryBushBlockMixin extends Block {
+	private SweetBerryBushBlockMixin(Properties properties) {
+		super(properties);
+	}
 
 	@Inject(method = "getCloneItemStack", at = @At("RETURN"), cancellable = true)
 	private void getCloneItemStack(BlockGetter level, BlockPos pos, BlockState state, CallbackInfoReturnable<ItemStack> cir) {
@@ -21,4 +27,10 @@ public abstract class SweetBerryBushBlockMixin {
 			cir.setReturnValue(new ItemStack(BGItems.SWEET_BERRY_PIPS.get()));
 		}
 	}
+
+	@Override
+	public Item asItem() {
+		return Items.SWEET_BERRIES;
+	}
+
 }


### PR DESCRIPTION
registering the pips items overrides the berries item in the Item.BY_BLOCK map. i overrided the asItem methods to stop the item filling from calling the incorrect item to fill.

also you dont need that BerryPipsBlockItem class lol